### PR TITLE
Added null type to 'value' field in data topic

### DIFF
--- a/avro/data.avpr
+++ b/avro/data.avpr
@@ -4,6 +4,6 @@
  "fields": [
      {"name": "channelId", "type": "string"},
      {"name": "timestamp",  "type": "string"},
-     {"name": "value", "type": "float"}
+     {"name": "value", "type": ["null", "float"]}
  ]
 }


### PR DESCRIPTION
This change to the Avro schema for the data topic adds support for NULL data values in the data topic. This change is **untested**.